### PR TITLE
Update make release action to have same toolchain as build

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
-            override: true
-            components: rustfmt, clippy
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
       - name: Cache cargo registry
         uses: actions/cache@v3.0.2
         with:


### PR DESCRIPTION
Release seems to be failing because the toolchain used here is different to the one in rust-toolchain