### PR TITLE
Fix DiskSource to use the correct fields

### DIFF
--- a/oxide/src/types.rs
+++ b/oxide/src/types.rs
@@ -468,7 +468,7 @@ impl std::str::FromStr for DiskSource {
             j = format!(
                 r#"{{
 "type": "blank",
-"image_id": {}
+"block_size": {}
         }}"#,
                 serde_json::json!(i64::from_str(&content).unwrap())
             );
@@ -477,7 +477,7 @@ impl std::str::FromStr for DiskSource {
             j = format!(
                 r#"{{
 "type": "snapshot",
-"image_id": "{}"
+"snapshot_id": "{}"
         }}"#,
                 content
             );


### PR DESCRIPTION
Currently when running the `$ oxide disk create` command, I get the following error:

```console
Oxide API internal error: unable to parse body: missing field `block_size` at line 1 column 85
```

Looking at the [spec](https://github.com/oxidecomputer/omicron/blob/main/openapi/nexus.json#L5444-L5532), the properties should be `block_size` for `blank`, `snapshot_id` for `snapshot`, `image_id` for `image`, and `image_id` for `global_image` instead of `image_id` for each type.

I've made a couple of changes and tried several other things but I seem to be stuck 😢 Could you help me with this one @jessfraz ?

Related: https://github.com/oxidecomputer/cli/pull/175