### PR TITLE
Fix DiskSource type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,9 +575,9 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "ipnetwork"
-version = "0.19.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
+checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
 dependencies = [
  "serde",
 ]

--- a/generator/src/types.rs
+++ b/generator/src/types.rs
@@ -372,6 +372,10 @@ fn do_one_of_type(
         return crate::types_templates::IP_NET.to_string();
     }
 
+    if sn == "DiskSource" {
+        return crate::types_templates::DISK_SOURCE.to_string();
+    }
+
     let mut tag = "";
     let mut content = "";
     let mut omap: Vec<crate::TypeId> = Default::default();

--- a/generator/src/types.rs
+++ b/generator/src/types.rs
@@ -338,9 +338,7 @@ fn render_property(
         }
 
         // Hide things from the table that don't implement display.
-        if (rt.starts_with("Vec<")
-            || rt.starts_with("Option<")
-            || rt == "VpcFirewallRuleFilter")
+        if (rt.starts_with("Vec<") || rt.starts_with("Option<") || rt == "VpcFirewallRuleFilter")
             && sn != "VpcFirewallRuleFilter"
         {
             a(r#"#[header(hidden = true)]"#);
@@ -508,20 +506,16 @@ fn do_one_of_type(
         ));
         if sn == "DiskSource" {
             a(&format!(
-                "   let mut content: String = \
-             match serde_json::from_value(j[\"{}\"].clone()) {{ \
-             Ok(v) => v, \
-                Err(_) => {{ \
-                let int : i64 = serde_json::from_value(j[\"{}\"].clone()).unwrap_or_default(); \
-                format!(\"{{}}\", int) \
-                }} \
-                }};",
+                "   let mut content: String = match serde_json::from_value(j[\"{}\"].clone()) {{ \
+                 Ok(v) => v, Err(_) => {{ let int : i64 = \
+                 serde_json::from_value(j[\"{}\"].clone()).unwrap_or_default(); format!(\"{{}}\", \
+                 int) }} }};",
                 content, content
             ));
         } else {
             a(&format!(
                 "   let mut content: String = \
-             serde_json::from_value(j[\"{}\"].clone()).unwrap_or_default();",
+                 serde_json::from_value(j[\"{}\"].clone()).unwrap_or_default();",
                 content
             ));
         }

--- a/oxide/Cargo.toml
+++ b/oxide/Cargo.toml
@@ -14,9 +14,9 @@ bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-humanize = "^0.2.1"
 dirs = { version = "^4.0.0", optional = true }
-http = "^0.2.7"
+http = "^0.2.4"
 hyperx = "1"
-ipnetwork = "^0.19"
+ipnetwork = "^0.18"
 log = { version = "^0.4", features = ["serde"] }
 mime = "0.3"
 parse-display = "^0.5"
@@ -38,7 +38,7 @@ dirs = "^4.0.0"
 Inflector = "^0.11.4"
 nom_pem = "4"
 pretty_assertions = "1"
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.8.0", features = ["full"] }
 
 [features]
 # enable etag-based http_cache functionality

--- a/oxide/src/tests.rs
+++ b/oxide/src/tests.rs
@@ -92,7 +92,9 @@ fn test_route_destination() {
 
 #[test]
 fn test_disk_source() {
-    let mut disk_source = crate::types::DiskSource::Snapshot("some-string-uuid".to_string());
+    let mut disk_source = crate::types::DiskSource::Snapshot {
+        snapshot_id: String::from("some-string-uuid").to_string(),
+    };
     let mut disk_source_str = format!("{}", disk_source);
     assert_eq!(disk_source_str, "snapshot=some-string-uuid");
 
@@ -100,7 +102,9 @@ fn test_disk_source() {
         crate::types::DiskSource::from_str("snapshot=some-string-uuid").unwrap();
     assert_eq!(disk_source_from_str, disk_source);
 
-    disk_source = crate::types::DiskSource::Image("some-image-string".to_string());
+    disk_source = crate::types::DiskSource::Image {
+        image_id: "some-image-string".to_string(),
+    };
     disk_source_str = format!("{}", disk_source);
     assert_eq!(disk_source_str, "image=some-image-string");
 
@@ -111,7 +115,9 @@ fn test_disk_source() {
     assert_eq!(variants.len(), 4);
     assert_eq!(variants, vec!["blank", "global_image", "image", "snapshot"]);
 
-    disk_source = crate::types::DiskSource::GlobalImage("some-image-string".to_string());
+    disk_source = crate::types::DiskSource::GlobalImage {
+        image_id: "some-image-string".to_string(),
+    };
     disk_source_str = format!("{}", disk_source);
     assert_eq!(disk_source_str, "global_image=some-image-string");
 
@@ -119,7 +125,7 @@ fn test_disk_source() {
         crate::types::DiskSource::from_str("global_image=some-image-string").unwrap();
     assert_eq!(disk_source_from_str, disk_source);
 
-    disk_source = crate::types::DiskSource::Blank(432);
+    disk_source = crate::types::DiskSource::Blank { block_size: 432 };
     disk_source_str = format!("{}", disk_source);
     assert_eq!(disk_source_str, "blank=432");
 

--- a/oxide/src/types.rs
+++ b/oxide/src/types.rs
@@ -433,16 +433,25 @@ impl fmt::Display for DiskSource {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let j = serde_json::json!(self);
         let mut tag: String = serde_json::from_value(j["type"].clone()).unwrap_or_default();
-        let mut content: String = match serde_json::from_value(j["image_id"].clone()) {
+
+        let mut value = "image_id";
+        if tag == *"blank" {
+            value = "block_size";
+        };
+        if tag == *"snapshot" {
+            value = "snapshot_id";
+        };
+
+        let mut content: String = match serde_json::from_value(j[value].clone()) {
             Ok(v) => v,
             Err(_) => {
-                let int: i64 = serde_json::from_value(j["image_id"].clone()).unwrap_or_default();
+                let int: i64 = serde_json::from_value(j[value].clone()).unwrap_or_default();
                 format!("{}", int)
             }
         };
         if content.is_empty() {
             let map: std::collections::HashMap<String, String> =
-                serde_json::from_value(j["image_id"].clone()).unwrap_or_default();
+                serde_json::from_value(j[value].clone()).unwrap_or_default();
             if let Some((_, v)) = map.iter().next() {
                 content = v.to_string();
             }

--- a/oxide/src/types.rs
+++ b/oxide/src/types.rs
@@ -421,12 +421,12 @@ pub struct Disk {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-#[serde(tag = "type", content = "image_id")]
+#[serde(tag = "type")]
 pub enum DiskSource {
-    Blank(i64),
-    Snapshot(String),
-    Image(String),
-    GlobalImage(String),
+    Blank { block_size: i64 },
+    Snapshot { snapshot_id: String },
+    Image { image_id: String },
+    GlobalImage { image_id: String },
 }
 
 impl fmt::Display for DiskSource {
@@ -468,7 +468,7 @@ impl std::str::FromStr for DiskSource {
             j = format!(
                 r#"{{
 "type": "blank",
-"image_id": {}
+"block_size": {}
         }}"#,
                 serde_json::json!(i64::from_str(&content).unwrap())
             );
@@ -477,7 +477,7 @@ impl std::str::FromStr for DiskSource {
             j = format!(
                 r#"{{
 "type": "snapshot",
-"image_id": "{}"
+"snapshot_id": "{}"
         }}"#,
                 content
             );


### PR DESCRIPTION
Related: https://github.com/oxidecomputer/cli/issues/180

Fixes the DiskSource type to be able to create disks.

Tested with the CLI as well:

```console
$ ./target/debug/oxide disk create --project myproject --organization corp test7 --disk-source blank=512
disk description: sdf
disk size: 1024
✔ Created disk test7 in corp/myproject

$ ./target/debug/oxide disk create --project myproject --organization corp test9
disk description: kjh
Input a image or snapshot id for the disk source: blank
blank value?: 512
disk size: 1024
Using 1024 bytes (1024 B)
✔ Created disk test9 in corp/myproject
```

I am not sure why, but running `make generate` reverted some dependency versions to what they were before I recently merged some dependabot PRs 🤔  I am leaving them this way since those updated changes seemed to break the CLI as well.