### PR TITLE
fix release GH action

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Publish release
         shell: bash
         run: |
-          cargo publish --token ${{secrets.CARGO_TOKEN}}
+          cargo publish --token ${{secrets.CARGO_TOKEN}} -p oxide
       - name: Create a Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Hopefully this should fix the latest release action failure https://github.com/oxidecomputer/oxide.rs/runs/6911161265?check_suite_focus=true